### PR TITLE
Fixed the github_repo_url to point to its new location

### DIFF
--- a/iot-mashup.yaml
+++ b/iot-mashup.yaml
@@ -1,4 +1,4 @@
-github_repo_url: https://github.com/weimeilin79/iot-mashup
+github_repo_url: https://github.com/jbossdemocentral/jboss-fuse-iot-mashup
 title: IoT mash up 
 technologies:
   - JBoss Fuse


### PR DESCRIPTION
This was breaking the JBoss Developer build. We've had to remove this demo from the site until this is fixed.